### PR TITLE
Use base-orphans to export orphan Functor instances

### DIFF
--- a/core/Test/Framework/Runners/Console.hs
+++ b/core/Test/Framework/Runners/Console.hs
@@ -1,5 +1,3 @@
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
 module Test.Framework.Runners.Console (
         defaultMain, defaultMainWithArgs, defaultMainWithOpts,
         SuppliedRunnerOptions, optionsDescription,
@@ -26,16 +24,7 @@ import System.IO
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
 #endif
-
-#if !MIN_VERSION_base(4,7,0)
-instance Functor OptDescr where
-    fmap f (Option a b arg_descr c) = Option a b (fmap f arg_descr) c
-
-instance Functor ArgDescr where
-    fmap f (NoArg a) = NoArg (f a)
-    fmap f (ReqArg g s) = ReqArg (f . g) s
-    fmap f (OptArg g s) = OptArg (f . g) s
-#endif
+import Data.Orphans ()
 
 -- | @Nothing@ signifies that usage information should be displayed.
 -- @Just@ simply gives us the contribution to overall options by the command line option.

--- a/core/Test/Framework/Runners/Console.hs
+++ b/core/Test/Framework/Runners/Console.hs
@@ -24,7 +24,9 @@ import System.IO
 #if !MIN_VERSION_base(4,8,0)
 import Data.Monoid
 #endif
+#if !(MIN_VERSION_base(4,7,0))
 import Data.Orphans ()
+#endif
 
 -- | @Nothing@ signifies that usage information should be displayed.
 -- @Just@ simply gives us the contribution to overall options by the command line option.

--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -47,7 +47,8 @@ Library
                                 Test.Framework.Utilities
 
         Build-Depends:          ansi-terminal >= 0.4.0, ansi-wl-pprint >= 0.5.1,
-                                base >= 4.3 && < 5, random >= 1.0, containers >= 0.1,
+                                base >= 4.3 && < 5, base-orphans >= 0.1,
+                                random >= 1.0, containers >= 0.1,
                                 regex-posix >= 0.72,
                                 old-locale >= 1.0,
                                 time >= 1.1.2 && < 1.6,

--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -18,6 +18,9 @@ Flag Tests
         Description:    Build the tests
         Default:        False
 
+Flag Base47
+        Description:    Use base-4.7 or later
+        Default:        True
 
 Library
         Exposed-Modules:        Test.Framework
@@ -47,12 +50,16 @@ Library
                                 Test.Framework.Utilities
 
         Build-Depends:          ansi-terminal >= 0.4.0, ansi-wl-pprint >= 0.5.1,
-                                base >= 4.3 && < 5, base-orphans >= 0.1,
                                 random >= 1.0, containers >= 0.1,
                                 regex-posix >= 0.72,
                                 old-locale >= 1.0,
                                 time >= 1.1.2 && < 1.6,
                                 xml >= 1.3.5, hostname >= 1.0
+
+        if flag(Base47)
+                Build-Depends:  base >= 4.7 && < 5
+        else
+                Build-Depends:  base >= 4.3 && < 4.7, base-orphans >= 0.1 && < 0.4
 
         Extensions:             CPP
                                 PatternGuards

--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -59,7 +59,7 @@ Library
         if flag(Base47)
                 Build-Depends:  base >= 4.7 && < 5
         else
-                Build-Depends:  base >= 4.3 && < 4.7, base-orphans >= 0.1 && < 0.4
+                Build-Depends:  base >= 4.3 && < 4.7, base-orphans >= 0.1 && < 0.5
 
         Extensions:             CPP
                                 PatternGuards


### PR DESCRIPTION
Currently, `test-framework` defines orphan `Functor` instances for `OptDescr` and `ArgDescr`. However, there is at least one other package that exports these same orphan instances ([`hsbencher`](https://github.com/rrnewton/HSBencher/blob/282603bc236d53021cc2bd512d23889bb58a1f76/hsbencher/src/HSBencher/Types.hs#L911-923)), possibly others. If these packages were used together on an old version of GHC, it could lead to instance conflicts.

To help mitigate this possibility, this pull request imports these instances from the `base-orphans` library (which exports backported instances introduced in later versions of `base`, including the aforementioned ones). This way, we can keep all of these orphan instances in one package so that `hsbencher`, `test-framework`, etc. can coexist.