### PR TITLE
test-framework-hunit.cabal: Require HUnit < 1.3

### DIFF
--- a/hunit/test-framework-hunit.cabal
+++ b/hunit/test-framework-hunit.cabal
@@ -24,7 +24,7 @@ Flag Base3
 Library
         Exposed-Modules:        Test.Framework.Providers.HUnit
 
-        Build-Depends:          test-framework >= 0.2.0, HUnit >= 1.2 && < 2, extensible-exceptions >= 0.1.1 && < 0.2.0
+        Build-Depends:          test-framework >= 0.2.0, HUnit >= 1.2 && < 1.3, extensible-exceptions >= 0.1.1 && < 0.2.0
         if flag(base3)
                 Build-Depends:          base >= 3 && < 4
         else


### PR DESCRIPTION
HUnit 1.3 breaks test-framework-hunit so add an upper bound.
