### PR TITLE
Allow HUnit 1.5

### DIFF
--- a/hunit/test-framework-hunit.cabal
+++ b/hunit/test-framework-hunit.cabal
@@ -24,7 +24,7 @@ Flag Base3
 Library
         Exposed-Modules:        Test.Framework.Providers.HUnit
 
-        Build-Depends:          test-framework >= 0.2.0, HUnit >= 1.2 && < 1.5, extensible-exceptions >= 0.1.1 && < 0.2.0
+        Build-Depends:          test-framework >= 0.2.0, HUnit >= 1.2 && < 1.6, extensible-exceptions >= 0.1.1 && < 0.2.0
         if flag(base3)
                 Build-Depends:          base >= 3 && < 4
         else


### PR DESCRIPTION
HUnit has had another major version bump!  I believe it does not affect anything used or re-exported by test-framework-hunit - it's just a change to `asserEqual` - and I have checked that test-framework works with HUnit-1.5.0.0 in the context of the tests for xmlhtml.