### PR TITLE
Recommend test-framework-quickcheck2

### DIFF
--- a/core/Test/Framework/Core.hs
+++ b/core/Test/Framework/Core.hs
@@ -31,7 +31,7 @@ type TestName = String
 type TestTypeName = String
 
 -- | Main test data type: builds up a list of tests to be run. Users should use the
--- utility functions in e.g. the test-framework-hunit and test-framework-quickcheck
+-- utility functions in e.g. the test-framework-hunit and test-framework-quickcheck2
 -- packages to create instances of 'Test', and then build them up into testsuites
 -- by using 'testGroup' and lists.
 --


### PR DESCRIPTION
The doc currently refers to `test-framework-quickcheck`, which doesn't support the latest version of QuickCheck. After a bit of poking around, it seems that `test-framework-quickcheck2` does, though. I'm a bit confused on why there are two of them, but it seems like the second one is the one that we ought to be recommending.