### PR TITLE
Allow HUnit 1.6

### DIFF
--- a/hunit/test-framework-hunit.cabal
+++ b/hunit/test-framework-hunit.cabal
@@ -24,7 +24,7 @@ Flag Base3
 Library
         Exposed-Modules:        Test.Framework.Providers.HUnit
 
-        Build-Depends:          test-framework >= 0.2.0, HUnit >= 1.2 && < 1.6, extensible-exceptions >= 0.1.1 && < 0.2.0
+        Build-Depends:          test-framework >= 0.2.0, HUnit >= 1.2 && < 1.7, extensible-exceptions >= 0.1.1 && < 0.2.0
         if flag(base3)
                 Build-Depends:          base >= 3 && < 4
         else


### PR DESCRIPTION
I don't believe this affects the exposed API of test-framework-hunit, and I've run the dejafu tests against this version bump with no issues.