### PR TITLE
Added Semigroup instances, in preparation for base 4.11

### DIFF
--- a/core/Test/Framework/Options.hs
+++ b/core/Test/Framework/Options.hs
@@ -4,6 +4,7 @@ import Test.Framework.Seed
 import Test.Framework.Utilities
 
 import Data.Monoid
+import Data.Semigroup as Sem hiding (Last(..))
 
 
 type TestOptions = TestOptions' Maybe
@@ -23,6 +24,16 @@ data TestOptions' f = TestOptions {
         -- ^ The number of microseconds to run tests for before considering them a failure
     }
 
+instance Sem.Semigroup (TestOptions' Maybe) where
+    to1 <> to2 = TestOptions {
+            topt_seed = getLast (mappendBy (Last . topt_seed) to1 to2),
+            topt_maximum_generated_tests = getLast (mappendBy (Last . topt_maximum_generated_tests) to1 to2),
+            topt_maximum_unsuitable_generated_tests = getLast (mappendBy (Last . topt_maximum_unsuitable_generated_tests) to1 to2),
+            topt_maximum_test_size = getLast (mappendBy (Last . topt_maximum_test_size) to1 to2),
+            topt_maximum_test_depth = getLast (mappendBy (Last . topt_maximum_test_depth) to1 to2),
+            topt_timeout = getLast (mappendBy (Last . topt_timeout) to1 to2)
+        }
+
 instance Monoid (TestOptions' Maybe) where
     mempty = TestOptions {
             topt_seed = Nothing,
@@ -33,11 +44,4 @@ instance Monoid (TestOptions' Maybe) where
             topt_timeout = Nothing
         }
     
-    mappend to1 to2 = TestOptions {
-            topt_seed = getLast (mappendBy (Last . topt_seed) to1 to2),
-            topt_maximum_generated_tests = getLast (mappendBy (Last . topt_maximum_generated_tests) to1 to2),
-            topt_maximum_unsuitable_generated_tests = getLast (mappendBy (Last . topt_maximum_unsuitable_generated_tests) to1 to2),
-            topt_maximum_test_size = getLast (mappendBy (Last . topt_maximum_test_size) to1 to2),
-            topt_maximum_test_depth = getLast (mappendBy (Last . topt_maximum_test_depth) to1 to2),
-            topt_timeout = getLast (mappendBy (Last . topt_timeout) to1 to2)
-        }
+    mappend = (Sem.<>)

--- a/core/Test/Framework/Runners/Options.hs
+++ b/core/Test/Framework/Runners/Options.hs
@@ -8,6 +8,7 @@ import Test.Framework.Utilities
 import Test.Framework.Runners.TestPattern
 
 import Data.Monoid
+import Data.Semigroup as Sem hiding (Last(..))
 
 data ColorMode = ColorAuto | ColorNever | ColorAlways
 
@@ -24,6 +25,18 @@ data RunnerOptions' f = RunnerOptions {
         ropt_list_only  :: f Bool
     }
 
+instance Semigroup (RunnerOptions' Maybe) where
+    ro1 <> ro2 = RunnerOptions {
+            ropt_threads = getLast (mappendBy (Last . ropt_threads) ro1 ro2),
+            ropt_test_options = mappendBy ropt_test_options ro1 ro2,
+            ropt_test_patterns = mappendBy ropt_test_patterns ro1 ro2,
+            ropt_xml_output = mappendBy ropt_xml_output ro1 ro2,
+            ropt_xml_nested = getLast (mappendBy (Last . ropt_xml_nested) ro1 ro2),
+            ropt_color_mode = getLast (mappendBy (Last . ropt_color_mode) ro1 ro2),
+            ropt_hide_successes = getLast (mappendBy (Last . ropt_hide_successes) ro1 ro2),
+            ropt_list_only      = getLast (mappendBy (Last . ropt_list_only)      ro1 ro2)
+        }
+
 instance Monoid (RunnerOptions' Maybe) where
     mempty = RunnerOptions {
             ropt_threads = Nothing,
@@ -36,13 +49,4 @@ instance Monoid (RunnerOptions' Maybe) where
             ropt_list_only      = Nothing
         }
 
-    mappend ro1 ro2 = RunnerOptions {
-            ropt_threads = getLast (mappendBy (Last . ropt_threads) ro1 ro2),
-            ropt_test_options = mappendBy ropt_test_options ro1 ro2,
-            ropt_test_patterns = mappendBy ropt_test_patterns ro1 ro2,
-            ropt_xml_output = mappendBy ropt_xml_output ro1 ro2,
-            ropt_xml_nested = getLast (mappendBy (Last . ropt_xml_nested) ro1 ro2),
-            ropt_color_mode = getLast (mappendBy (Last . ropt_color_mode) ro1 ro2),
-            ropt_hide_successes = getLast (mappendBy (Last . ropt_hide_successes) ro1 ro2),
-            ropt_list_only      = getLast (mappendBy (Last . ropt_list_only)      ro1 ro2)
-        }
+    mappend = (Sem.<>)

--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -80,6 +80,8 @@ Library
         -- workaround https://github.com/haskell/cabal/issues/4443
         if impl(ghc >= 7.2)
                 Default-Extensions: NondecreasingIndentation
+        if !impl(ghc >= 8.0)
+                Build-Depends: semigroups == 0.18.*
 
         Ghc-Options:            -Wall
 


### PR DESCRIPTION
Base 4.11 will have Semigroup as a superclass of Monoid

https://github.com/ghc/ghc/commit/8ae263ceb3566a7c82336400b09cb8f381217405