### PR TITLE
Bump upper bound on the time package.

### DIFF
--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -52,7 +52,7 @@ Library
                               , containers     >= 0.1    && < 0.7
                               , regex-posix    >= 0.72   && < 0.96
                               , old-locale     >= 1.0    && < 1.1
-                              , time           >= 1.1.2  && < 1.9
+                              , time           >= 1.1.2  && < 1.10
                               , xml            >= 1.3.5  && < 1.4
                               , hostname       >= 1.0    && < 1.1
 


### PR DESCRIPTION
This compiles fine and allows us to build test-framework with recent
GHC HEAD.