### PR TITLE
Fixing the display of path

### DIFF
--- a/core/src/Test/Framework/Runners/Console.hs
+++ b/core/src/Test/Framework/Runners/Console.hs
@@ -164,7 +164,7 @@ listTests tests = "\ntest-framework: All available tests:\n"++
   where
     showTest :: String -> Test -> [String]
     showTest path (Test name _testlike)    = ["  "++path ++ name]
-    showTest path (TestGroup name gtests)   = concatMap (showTest (path++":"++name)) gtests
+    showTest path (TestGroup name gtests)   = concatMap (showTest (path++name++":")) gtests
     showTest path (PlusTestOptions _ test) = showTest path test
     showTest path (BuildTestBracketed _)   = ["  "++path ++ "<created at runtime>"]
 


### PR DESCRIPTION
Now the path is displayed this way:
:<rootGroup>:<subgroup><testName>

which is probably not desired. More desired format is probably:

<rootGroup>:<subgroup>:<testName>

this PR fixes that.