### PR TITLE
Allow time 1.10 and 1.11

### DIFF
--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -52,7 +52,7 @@ Library
                               , containers     >= 0.1    && < 0.7
                               , regex-posix    >= 0.72   && < 0.97
                               , old-locale     >= 1.0    && < 1.1
-                              , time           >= 1.1.2  && < 1.10
+                              , time           >= 1.1.2  && < 1.12
                               , xml            >= 1.3.5  && < 1.4
                               , hostname       >= 1.0    && < 1.1
 


### PR DESCRIPTION
http://hackage.haskell.org/package/time-1.11/changelog

Tested locally with

    cabal test all --constraint 'time == 1.10'

and

    cabal test all --constraint 'time == 1.11'