### PR TITLE
Relax `test-framework` upper bound to accommodate dependency on `ansi-terminal-1.0`

### DIFF
--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -62,7 +62,7 @@ Library
                                 Test.Framework.Utilities
 
         Build-Depends:          base           >= 4.3    && < 5
-                              , ansi-terminal  >= 0.4.0  && < 0.12
+                              , ansi-terminal  >= 0.4.0  && < 1.1
                               , ansi-wl-pprint >= 0.5.1  && < 0.7
                               , random         >= 1.0    && < 1.3
                               , containers     >= 0.1    && < 0.7


### PR DESCRIPTION
`ansi-terminal-1.0` is released on Hackage.

See also https://github.com/commercialhaskell/stackage/issues/6976.

Tested by building `test-framework` package (only) with Stack >= 2.9.3 and `stack.yaml`:
~~~yaml
resolver: lts-20.21 # GHC 9.2.7

packages:
- core

extra-deps:
- ansi-terminal-1.0
- ansi-terminal-types-0.11.5

allow-newer: true
allow-newer-deps:
- ansi-wl-pprint
~~~