### PR TITLE
Allow ansi-wl-pprint 1.0

### DIFF
--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -64,7 +64,7 @@ Library
 
         Build-Depends:          base           >= 4.3    && < 5
                               , ansi-terminal  >= 0.4.0  && < 1.1
-                              , ansi-wl-pprint >= 0.5.1  && < 0.7
+                              , ansi-wl-pprint >= 0.5.1  && < 1.1
                               , random         >= 1.0    && < 1.3
                               , containers     >= 0.1    && < 0.7
                               , regex-posix    >= 0.72   && < 0.97


### PR DESCRIPTION
Tested using

    cabal test --constraint 'ansi-wl-pprint ^>=1.0'
