### PR TITLE
v0.8.2.1-r1: allow newer containers, drop dependencies before LTS 7.24

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -235,6 +235,8 @@ jobs:
           cat >> cabal.project <<EOF
           package libxml
             extra-include-dirs: /usr/include/libxml2
+
+          allow-newer: containers
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(test-framework|test-framework-example|test-framework-hunit|test-framework-quickcheck2)$/; }' >> cabal.project.local
           cat cabal.project
@@ -279,6 +281,16 @@ jobs:
         run: |
           rm -f cabal.project.local
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
+      - name: prepare for constraint sets
+        run: |
+          rm -f cabal.project.local
+      - name: constraint set containers-0.8
+        run: |
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all --dry-run ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then cabal-plan topo | sort ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' --dependencies-only -j2 all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-build $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then $CABAL v2-test $ARG_COMPILER --enable-tests --disable-benchmarks --constraint='containers ^>=0.8' all ; fi
       - name: save cache
         if: always()
         uses: actions/cache/save@v4

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -6,3 +6,12 @@ raw-project
   -- On Debian/Ubuntu you may need the following to workaround an issue in libxml's packaging
   package libxml
     extra-include-dirs: /usr/include/libxml2
+
+constraint-set containers-0.8
+  ghc: >= 8.2
+  constraints: containers ^>=0.8
+  tests: True
+  run-tests: True
+
+raw-project
+  allow-newer: containers

--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -1,6 +1,7 @@
 Cabal-Version:       1.18
 Name:                test-framework
 Version:             0.8.2.1
+x-revision:          1
 Category:            Testing
 Synopsis:            Framework for running and organising tests, with HUnit and QuickCheck support
 Description:         Allows tests such as QuickCheck properties and HUnit test cases to be assembled into test groups, run in
@@ -59,16 +60,17 @@ Library
                                 Test.Framework.Runners.XML
                                 Test.Framework.Utilities
 
-        Build-Depends:          base           >= 4.9    && < 5
-                              , ansi-terminal  >= 0.4.0  && < 1.2
-                              , ansi-wl-pprint >= 0.6.7  && < 1.1
-                              , random         >= 1.1    && < 1.4
-                              , containers     >= 0.1    && < 0.8
-                              , regex-posix    >= 0.72   && < 0.97
-                              , old-locale     >= 1.0    && < 1.1
-                              , time           >= 1.6    && < 1.15
-                              , xml            >= 1.3.5  && < 1.4
-                              , hostname       >= 1.0    && < 1.1
+        -- Lower bounds picked from LTS-7.24 (GHC 8.0.1)
+        Build-Depends:          base           >= 4.9      && < 5
+                              , ansi-terminal  >= 0.6.3    && < 1.2
+                              , ansi-wl-pprint >= 0.6.7    && < 1.1
+                              , random         >= 1.1      && < 1.4
+                              , containers     >= 0.5.7    && < 1
+                              , regex-posix    >= 0.95.2   && < 0.97
+                              , old-locale     >= 1.0      && < 1.1
+                              , time           >= 1.6      && < 1.15
+                              , xml            >= 1.3.14   && < 1.4
+                              , hostname       >= 1.0      && < 1.1
 
         Default-Language:       Haskell2010
         Default-Extensions:     CPP
@@ -111,20 +113,21 @@ Test-Suite test-framework-tests
         -- Doe to libxml dependency, the testsuite is not buildable on e.g. MacOS
         -- Buildable:              False
 
+        -- Lower bounds from LTS-9.21 (GHC 8.0.2)
         Build-Depends:          HUnit          >= 1.5.0.0
                               , QuickCheck     >= 2.9.2   && < 2.16
                               , base           >= 4.9     && < 5
                               , random         >= 1.1
-                              , containers     >= 0.1
-                              , ansi-terminal  >= 0.4.0
+                              , containers     >= 0.5.7
+                              , ansi-terminal  >= 0.6.3
                               , ansi-wl-pprint >= 0.6.7
-                              , regex-posix    >= 0.72
+                              , regex-posix    >= 0.95.2
                               , old-locale     >= 1.0
                               , time           >= 1.6
-                              , xml            >= 1.3.5
+                              , xml            >= 1.3.14
                               , hostname       >= 1.0
                               , libxml         >= 0.1.1
-                              , bytestring     >= 0.9
+                              , bytestring     >= 0.10.8
                               , semigroups     >= 0.18
                               , utf8-string    >= 1.0.1.1 && <1.1
 


### PR DESCRIPTION
We support GHC 8.0 and up, so we can raise the lower bounds of some dependencies.
