### PR TITLE
v0.8.2.2: remove libxml dependency

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20250216
+# version: 0.19.20250330
 #
-# REGENDATA ("0.19.20250216",["github","cabal.project"])
+# REGENDATA ("0.19.20250330",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -32,9 +32,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.12.1
+          - compiler: ghc-9.12.2
             compilerKind: ghc
-            compilerVersion: 9.12.1
+            compilerVersion: 9.12.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.1
@@ -47,9 +47,9 @@ jobs:
             compilerVersion: 9.8.4
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.6.6
+          - compiler: ghc-9.6.7
             compilerKind: ghc
-            compilerVersion: 9.6.6
+            compilerVersion: 9.6.7
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.4.8
@@ -107,12 +107,12 @@ jobs:
       - name: Install GHCup
         run: |
           mkdir -p "$HOME/.ghcup/bin"
-          curl -sL https://downloads.haskell.org/ghcup/0.1.30.0/x86_64-linux-ghcup-0.1.30.0 > "$HOME/.ghcup/bin/ghcup"
+          curl -sL https://downloads.haskell.org/ghcup/0.1.50.1/x86_64-linux-ghcup-0.1.50.1 > "$HOME/.ghcup/bin/ghcup"
           chmod a+x "$HOME/.ghcup/bin/ghcup"
       - name: Install cabal-install
         run: |
-          "$HOME/.ghcup/bin/ghcup" install cabal 3.12.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
-          echo "CABAL=$HOME/.ghcup/bin/cabal-3.12.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+          "$HOME/.ghcup/bin/ghcup" install cabal 3.14.1.1-p1 || (cat "$HOME"/.ghcup/logs/*.* && false)
+          echo "CABAL=$HOME/.ghcup/bin/cabal-3.14.1.1-p1 -vnormal+nowrap" >> "$GITHUB_ENV"
       - name: Install GHC (GHCup)
         if: matrix.setup-method == 'ghcup'
         run: |

--- a/core/ChangeLog.md
+++ b/core/ChangeLog.md
@@ -1,3 +1,10 @@
+#### 0.8.2.2
+
+_2025-04-11, Andreas Abel_
+
+- Drop `libxml` dependency in testsuite
+- Tested building with GHC 8.0 - 9.12.2
+
 #### 0.8.2.1
 
 _2025-02-26, Andreas Abel_

--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -16,10 +16,10 @@ Bug-Reports:         https://github.com/haskell/test-framework/issues
 Build-Type:          Simple
 
 Tested-With:
-  GHC == 9.12.1
+  GHC == 9.12.2
   GHC == 9.10.1
   GHC == 9.8.4
-  GHC == 9.6.6
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -1,7 +1,6 @@
 Cabal-Version:       1.18
 Name:                test-framework
-Version:             0.8.2.1
-x-revision:          1
+Version:             0.8.2.2
 Category:            Testing
 Synopsis:            Framework for running and organising tests, with HUnit and QuickCheck support
 Description:         Allows tests such as QuickCheck properties and HUnit test cases to be assembled into test groups, run in
@@ -110,9 +109,6 @@ Test-Suite test-framework-tests
         Main-Is:                Tests.hs
         Type:                   exitcode-stdio-1.0
 
-        -- Doe to libxml dependency, the testsuite is not buildable on e.g. MacOS
-        -- Buildable:              False
-
         -- Lower bounds from LTS-9.21 (GHC 8.0.2)
         Build-Depends:          HUnit          >= 1.5.0.0
                               , QuickCheck     >= 2.9.2   && < 2.16
@@ -126,10 +122,8 @@ Test-Suite test-framework-tests
                               , time           >= 1.6
                               , xml            >= 1.3.14
                               , hostname       >= 1.0
-                              , libxml         >= 0.1.1
                               , bytestring     >= 0.10.8
                               , semigroups     >= 0.18
-                              , utf8-string    >= 1.0.1.1 && <1.1
 
         Default-Language:       Haskell2010
         Default-Extensions:     CPP

--- a/core/test/Test/Framework/Tests/Runners/XMLTests.hs
+++ b/core/test/Test/Framework/Tests/Runners/XMLTests.hs
@@ -8,19 +8,14 @@ import Test.Framework.Runners.XML.JUnitWriter ( RunDescription(..), morphFlatTes
 
 import Test.HUnit.Base               ( Test(..), (@?=) )
 import Test.QuickCheck               ( Arbitrary, sized, Gen, oneof, listOf, arbitrary )
-import Test.QuickCheck.Property as P ( Property )
+import qualified Test.QuickCheck.Property as QC ( Property, property )
 
 import Control.Monad ( ap, liftM2, liftM3 )
 
 import Data.Maybe ( isJust )
 
-import qualified Data.ByteString.UTF8 as UTF8
-
-import qualified Text.XML.Light as XML         ( findAttr, unqual )
-import qualified Text.XML.LibXML.Parser as XML ( parseMemory_ )
-import qualified Text.XML.LibXML.Types as XML  ( Document )
-
-import Test.QuickCheck.Property as P (morallyDubiousIOProperty)
+import qualified Text.XML.Light as XML         ( Element, findAttr, unqual )
+import qualified Text.XML.Light.Input as XML   ( parseXMLDoc )
 
 -- | `Arbitrary` instance for `TestResult` generation.
 instance Arbitrary FinishedTest where
@@ -89,11 +84,11 @@ arbitraryXmlStr = listOf arbitraryXmlChar
 
 -- | Generate random `RunDescriptions`, serialize to (flat) XML strings, then check that they are XML
 -- TODO: check them against the JUnit schema
-property :: RunDescription -> P.Property
-property = morallyDubiousIOProperty . fmap isJust . parseSerialize
+property :: RunDescription -> QC.Property
+property = QC.property . isJust . parseSerialize
 
-parseSerialize :: RunDescription -> IO (Maybe XML.Document)
-parseSerialize = XML.parseMemory_ . UTF8.fromString . serialize False
+parseSerialize :: RunDescription -> Maybe XML.Element
+parseSerialize = XML.parseXMLDoc . serialize False
 
 -- | Verify that the group names are properly prepended to sub-tests.
 test :: Test

--- a/example/test-framework-example.cabal
+++ b/example/test-framework-example.cabal
@@ -12,10 +12,10 @@ Homepage:            https://github.com/haskell/test-framework#readme
 Build-Type:          Simple
 
 Tested-With:
-  GHC == 9.12.1
+  GHC == 9.12.2
   GHC == 9.10.1
   GHC == 9.8.4
-  GHC == 9.6.6
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/hunit/test-framework-hunit.cabal
+++ b/hunit/test-framework-hunit.cabal
@@ -13,10 +13,10 @@ Build-Type:          Simple
 Description:         @HUnit@ support for the @test-framework@ package.
 
 Tested-With:
-  GHC == 9.12.1
+  GHC == 9.12.2
   GHC == 9.10.1
   GHC == 9.8.4
-  GHC == 9.6.6
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/quickcheck2/test-framework-quickcheck2.cabal
+++ b/quickcheck2/test-framework-quickcheck2.cabal
@@ -13,10 +13,10 @@ Build-Type:          Simple
 Description:         Allows @QuickCheck-2@ properties to be used with the </package/test-framework test-framework package>.
 
 Tested-With:
-  GHC == 9.12.1
+  GHC == 9.12.2
   GHC == 9.10.1
   GHC == 9.8.4
-  GHC == 9.6.6
+  GHC == 9.6.7
   GHC == 9.4.8
   GHC == 9.2.8
   GHC == 9.0.2

--- a/stack-9.10.yaml
+++ b/stack-9.10.yaml
@@ -6,9 +6,6 @@ packages:
   - quickcheck2
   - example
 
-extra-deps:
-  - libxml-0.1.1
-
 ghc-options:
   $locals: >-
     -Wall

--- a/stack-9.4.yaml
+++ b/stack-9.4.yaml
@@ -6,9 +6,6 @@ packages:
   - quickcheck2
   - example
 
-extra-deps:
-  - libxml-0.1.1
-
 ghc-options:
   $locals: >-
     -Wall


### PR DESCRIPTION


- **Bump Haskell CI to GHC 9.12.2 and 9.6.7**
  

- **Drop libxml dependency, use Text.XML.Light.Input.parseXMLDoc instead**
  libxml is no longer maintained.
  
  The libxml parser was introduced in the very beginning (commit 240e81b242f5736461af783bf01afd08112fbf71), not clear why, maybe the `xml` package did not have parsing yet?
  Or maybe using a C library was for efficiency reasons...
  Can only speculate...
  
Candidate: https://hackage.haskell.org/package/test-framework-0.8.2.2/candidate

Re:
- https://github.com/commercialhaskell/stackage/issues/7697