### PR TITLE
Allow ansi-wl-pprint < 2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.19.20260104
+# version: 0.19.20260209
 #
-# REGENDATA ("0.19.20260104",["github","cabal.project"])
+# REGENDATA ("0.19.20260209",["github","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -23,6 +23,8 @@ on:
   merge_group:
     branches:
       - master
+  workflow_dispatch:
+    {}
 jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
@@ -40,9 +42,9 @@ jobs:
             compilerVersion: 9.14.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.12.2
+          - compiler: ghc-9.12.4
             compilerKind: ghc
-            compilerVersion: 9.12.2
+            compilerVersion: 9.12.4
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.10.3
@@ -196,7 +198,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           path: source
       - name: initial cabal.project for sdist
@@ -260,7 +262,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER $ARG_TESTS $ARG_BENCH --dry-run all
           cabal-plan
       - name: restore cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store
@@ -297,7 +299,7 @@ jobs:
           $CABAL v2-build $ARG_COMPILER --disable-tests --disable-benchmarks all
       - name: save cache
         if: always()
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           key: ${{ runner.os }}-${{ matrix.compiler }}-${{ github.sha }}
           path: ~/.cabal/store

--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -1,6 +1,7 @@
 Cabal-Version:       1.18
 Name:                test-framework
 Version:             0.8.2.3
+x-revision:          1
 
 Category:            Testing
 Synopsis:            Framework for running and organising tests, with HUnit and QuickCheck support
@@ -64,7 +65,7 @@ Library
         -- Lower bounds picked from LTS-7.24 (GHC 8.0.1)
         Build-Depends:          base           >= 4.9      && < 5
                               , ansi-terminal  >= 0.6.3    && < 1.2
-                              , ansi-wl-pprint >= 0.6.7    && < 1.1
+                              , ansi-wl-pprint >= 0.6.7    && < 2
                               , random         >= 1.1      && < 1.4
                               , containers     >= 0.5.7    && < 1
                               , regex-posix    >= 0.95.2   && < 0.97

--- a/core/test-framework.cabal
+++ b/core/test-framework.cabal
@@ -17,7 +17,7 @@ Build-Type:          Simple
 
 Tested-With:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7

--- a/example/test-framework-example.cabal
+++ b/example/test-framework-example.cabal
@@ -13,7 +13,7 @@ Build-Type:          Simple
 
 Tested-With:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7

--- a/hunit/test-framework-hunit.cabal
+++ b/hunit/test-framework-hunit.cabal
@@ -17,7 +17,7 @@ extra-doc-files:
 
 Tested-With:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7

--- a/quickcheck2/test-framework-quickcheck2.cabal
+++ b/quickcheck2/test-framework-quickcheck2.cabal
@@ -15,7 +15,7 @@ Description:         Allows @QuickCheck-2@ properties to be used with the </pack
 
 Tested-With:
   GHC == 9.14.1
-  GHC == 9.12.2
+  GHC == 9.12.4
   GHC == 9.10.3
   GHC == 9.8.4
   GHC == 9.6.7


### PR DESCRIPTION
- **Bump Haskell CI ghc 9.12 to 9.12.4**
  

- **v0.8.2.3 revision 1: allow ansi-wl-pprint < 2**
  